### PR TITLE
introduce service.annotations map

### DIFF
--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -11,4 +11,4 @@ name: uptime-kuma
 sources:
   - https://github.com/louislam/uptime-kuma
 type: application
-version: 2.1.0
+version: 2.1.1

--- a/charts/uptime-kuma/templates/service.yaml
+++ b/charts/uptime-kuma/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "uptime-kuma.fullname" . }}
   labels:
     {{- include "uptime-kuma.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/uptime-kuma/values.yaml
+++ b/charts/uptime-kuma/values.yaml
@@ -47,6 +47,7 @@ securityContext:
 service:
   type: ClusterIP
   port: 3001
+  annotations: {}
 
 ingress:
   enabled: false


### PR DESCRIPTION
- make service annotations configurable through value-map
  service.annotations

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Check if an open Issue exists that is solved by your changes.

 Thank you for contributing! I will try to test and integrate the change as soon as possible, but be aware that I can't immediately respond to every request.

 -->

**Description of the change**

This change enables the user of this helm chart to configure additional annotations for the service manifest.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

Additional annotations on service level can be used by different kubernetes providers to select the type of LoadBalancer that should be provisioned. This is useful if a user wants to only use private load balancers.

Such configurations could be then set through the value-map service.annotations:
    --set service.annotations.networking\\.gke\\.io/load-balancer-type="Internal" #gke
    --set service.annotations.service\\.beta\\.kubernetes\\.io/azure-load-balancer-internal="true" #aks
    --set service.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-ip-address-type="dualstack" #eks ipv4+ipv6

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

None that I can think of

<!-- Describe any known limitations with your change -->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
