### PR TITLE
Fix using default storageClass

### DIFF
--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -11,4 +11,4 @@ name: uptime-kuma
 sources:
   - https://github.com/louislam/uptime-kuma
 type: application
-version: 2.1.5
+version: 2.1.6

--- a/charts/uptime-kuma/templates/pvc.yaml
+++ b/charts/uptime-kuma/templates/pvc.yaml
@@ -12,7 +12,8 @@ spec:
   resources:
     requests:
       storage: {{ .Values.volume.size | quote }}
-  storageClassName: {{ .Values.volume.storageClassName | default "standard"}}
-  volumeMode: Filesystem
+  {{- with .Values.volume.storageClassName }}
+  storageClassName: {{ . }}
+  {{- end }}
 {{- end -}}
 {{- end -}}

--- a/charts/uptime-kuma/templates/statefulset.yaml
+++ b/charts/uptime-kuma/templates/statefulset.yaml
@@ -89,7 +89,8 @@ spec:
         resources:
           requests:
             storage: {{ .Values.volume.size }}
-        storageClassName: {{ .Values.volume.storageClassName | default "standard" }}
-        volumeMode: Filesystem
+        {{- with .Values.volume.storageClassName }}
+        storageClassName: {{ . }}
+        {{- end }}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Omitting storageClassName, when omitted in values.yaml.
Therefore, the real default storageClass is used.
Also removed the volumeModes because it is optional.

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Check if an open Issue exists that is solved by your changes.

 Thank you for contributing! I will try to test and integrate the change as soon as possible, but be aware that I can't immediately respond to every request.

 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
