### PR TITLE
Fix Default Port issue in Helm Chart

### DIFF
--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -11,4 +11,4 @@ name: uptime-kuma
 sources:
   - https://github.com/louislam/uptime-kuma
 type: application
-version: 2.1.7
+version: 2.1.8

--- a/charts/uptime-kuma/values.yaml
+++ b/charts/uptime-kuma/values.yaml
@@ -30,7 +30,11 @@ podAnnotations: {}
 podLabels:
   {}
   # app: uptime-kuma
-podEnv: {}
+  
+podEnv:
+  # a default port must be set. required by container
+  - name: "UPTIME_KUMA_PORT"
+    value: "3001"
 
 podSecurityContext:
   {}


### PR DESCRIPTION
Fix Helm chart - pod crashes with default values - requires a port to be set.

**Description of the change**

This change sets the default port for the Uptime Kuma container which is, by default, 3001.

**Benefits**

Fixes crashes when using the helm chart with default values

**Possible drawbacks**

Uptime Kuma can use a few env vars for options.port.  However , I chose UPTIME_KUMA_PORT as the default to use.

**Applicable issues**

  - fixes #1138

**Additional information**

Tested locally in K3s on v1.23.3+k3s1 (see freshbrewed.science for blog about Uptime Kuma and how I used)

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
