### PR TITLE
Add helm-docs to pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,6 @@ repos:
     hooks:
       - id: helmlint
   - repo: https://github.com/norwoodj/helm-docs
-      rev: v1.2.0
-      hooks:
-        - id: helm-docs
+    rev: v1.2.0
+    hooks:
+      - id: helm-docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,7 @@ repos:
     rev: v0.1.16 # Get the latest from: https://github.com/gruntwork-io/pre-commit/releases
     hooks:
       - id: helmlint
+  - repo: https://github.com/norwoodj/helm-docs
+      rev: v1.2.0
+      hooks:
+        - id: helm-docs

--- a/README.md
+++ b/README.md
@@ -25,12 +25,6 @@ To uninstall the chart:
 
     helm delete my-uptime-kuma --namespace monitoring
 
-## Values
+## Configuration
 
-| Value     | Default | Description                                                                                             |
-|-----------|---------|---------------------------------------------------------------------------------------------------------|
-| useDeploy | `true`    | If true the helm templates generates a K8S Deployment + PVC. If set to false it will use a StateFulset. |
-| volume.enabled | `true` | If false no PVC will be created and therefore no PV will be attached. |
-| volume.storageClassName | `standard` | If set the storage class referenced will be applied. Otherwise standard will be used. |
-| podEnv | `{}` | PodEnv is used to introduce environment variables for the docker container. |
-| existingClaim | `{}` | existingClaim is used to reuse an existing PersistentVolumeClaim |
+To get an overview of the configurable and default Values check out the Chart specific [README](./charts/uptime-kuma/README.md).

--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "1.11.4"
+appVersion: "1.13.1"
 deprecated: false
 description: A self-hosted Monitoring tool like "Uptime-Robot".
 home: https://github.com/dirsigler/uptime-kuma-helm
@@ -11,4 +11,4 @@ name: uptime-kuma
 sources:
   - https://github.com/louislam/uptime-kuma
 type: application
-version: 2.2.7
+version: 2.3.0

--- a/charts/uptime-kuma/README.md
+++ b/charts/uptime-kuma/README.md
@@ -1,0 +1,63 @@
+# uptime-kuma
+
+![Version: 2.2.7](https://img.shields.io/badge/Version-2.2.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.4](https://img.shields.io/badge/AppVersion-1.11.4-informational?style=flat-square)
+
+A self-hosted Monitoring tool like "Uptime-Robot".
+
+**Homepage:** <https://github.com/dirsigler/uptime-kuma-helm>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| dirsigler | <dennis@irsigler.dev> |  |
+
+## Source Code
+
+* <https://github.com/louislam/uptime-kuma>
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| autoscaling.enabled | bool | `false` |  |
+| autoscaling.maxReplicas | int | `10` |  |
+| autoscaling.minReplicas | int | `1` |  |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| fullnameOverride | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"louislam/uptime-kuma"` |  |
+| image.tag | string | `"1.11.4-alpine"` |  |
+| imagePullSecrets | list | `[]` |  |
+| ingress.annotations."nginx.ingress.kubernetes.io/proxy-read-timeout" | string | `"3600"` |  |
+| ingress.annotations."nginx.ingress.kubernetes.io/proxy-send-timeout" | string | `"3600"` |  |
+| ingress.annotations."nginx.ingress.kubernetes.io/server-snippets" | string | `"location / {\n  proxy_set_header Upgrade $http_upgrade;\n  proxy_http_version 1.1;\n  proxy_set_header X-Forwarded-Host $http_host;\n  proxy_set_header X-Forwarded-Proto $scheme;\n  proxy_set_header X-Forwarded-For $remote_addr;\n  proxy_set_header Host $host;\n  proxy_set_header Connection \"upgrade\";\n  proxy_set_header X-Real-IP $remote_addr;\n  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n  proxy_set_header   Upgrade $http_upgrade;\n  proxy_cache_bypass $http_upgrade;\n}\n"` |  |
+| ingress.enabled | bool | `false` |  |
+| ingress.extraLabels | object | `{}` |  |
+| ingress.hosts[0].host | string | `"chart-example.local"` |  |
+| ingress.hosts[0].paths[0].path | string | `"/"` |  |
+| ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
+| ingress.tls | list | `[]` |  |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| podAnnotations | object | `{}` |  |
+| podEnv | object | `{}` |  |
+| podLabels | object | `{}` |  |
+| podSecurityContext | object | `{}` |  |
+| replicaCount | int | `1` |  |
+| resources | object | `{}` |  |
+| securityContext | object | `{}` |  |
+| service.annotations | object | `{}` |  |
+| service.port | int | `3001` |  |
+| service.type | string | `"ClusterIP"` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.create | bool | `false` |  |
+| serviceAccount.name | string | `""` |  |
+| tolerations | list | `[]` |  |
+| useDeploy | bool | `true` |  |
+| volume.accessMode | string | `"ReadWriteOnce"` |  |
+| volume.enabled | bool | `true` |  |
+| volume.existingClaim | object | `{}` |  |
+| volume.size | string | `"4Gi"` |  |
+

--- a/charts/uptime-kuma/README.md
+++ b/charts/uptime-kuma/README.md
@@ -1,6 +1,6 @@
 # uptime-kuma
 
-![Version: 2.2.7](https://img.shields.io/badge/Version-2.2.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.4](https://img.shields.io/badge/AppVersion-1.11.4-informational?style=flat-square)
+![Version: 2.3.0](https://img.shields.io/badge/Version-2.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.13.1](https://img.shields.io/badge/AppVersion-1.13.1-informational?style=flat-square)
 
 A self-hosted Monitoring tool like "Uptime-Robot".
 
@@ -28,7 +28,7 @@ A self-hosted Monitoring tool like "Uptime-Robot".
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"louislam/uptime-kuma"` |  |
-| image.tag | string | `"1.11.4-alpine"` |  |
+| image.tag | string | `"1.13.1-alpine"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations."nginx.ingress.kubernetes.io/proxy-read-timeout" | string | `"3600"` |  |
 | ingress.annotations."nginx.ingress.kubernetes.io/proxy-send-timeout" | string | `"3600"` |  |
@@ -42,7 +42,8 @@ A self-hosted Monitoring tool like "Uptime-Robot".
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
-| podEnv | object | `{}` |  |
+| podEnv[0].name | string | `"UPTIME_KUMA_PORT"` |  |
+| podEnv[0].value | string | `"3001"` |  |
 | podLabels | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | replicaCount | int | `1` |  |

--- a/charts/uptime-kuma/values.yaml
+++ b/charts/uptime-kuma/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: louislam/uptime-kuma
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "1.11.4-alpine"
+  tag: "1.13.1-alpine"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -29,7 +29,10 @@ serviceAccount:
 podAnnotations: {}
 podLabels: {}
   # app: uptime-kuma
-podEnv: {}
+podEnv:
+  # a default port must be set. required by container
+  - name: "UPTIME_KUMA_PORT"
+    value: "3001"
 
 podSecurityContext: {}
   # fsGroup: 2000


### PR DESCRIPTION
**Description of the change**

Add the helm-docs utility to the pre-commit config

**Benefits**

When the pre-commit framework is used it removes the burden to add new values or changed defaults.

**Possible drawbacks**

**Applicable issues**

fixes #43 

**Additional information**

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
