### PR TITLE
Enable the use of strategy deployment

### DIFF
--- a/charts/uptime-kuma/templates/deployment.yaml
+++ b/charts/uptime-kuma/templates/deployment.yaml
@@ -12,6 +12,10 @@ spec:
   selector:
     matchLabels:
       {{- include "uptime-kuma.selectorLabels" . | nindent 6 }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}


### PR DESCRIPTION
**Description of the change**

The change is simple. I just wrote the needed template to be able to set the strategy. I will update the chart version and the variables after it's okay for you.

**Benefits**

You can select a different strategy, for instance, `Recreate`. The default is `RollingUpdate`, which cause trouble to the upgrades, as the PVC is attached to the running instance.

**Possible drawbacks**

None

**Applicable issues**

I haven't filled in an issue

**Additional information**

None

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
