### PR TITLE
Add service.nodePort value

### DIFF
--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -11,4 +11,4 @@ name: uptime-kuma
 sources:
   - https://github.com/louislam/uptime-kuma
 type: application
-version: 2.3.10
+version: 2.4.0

--- a/charts/uptime-kuma/README.md
+++ b/charts/uptime-kuma/README.md
@@ -51,6 +51,7 @@ A self-hosted Monitoring tool like "Uptime-Robot".
 | securityContext | object | `{}` |  |
 | service.annotations | object | `{}` |  |
 | service.port | int | `3001` |  |
+| service.nodePort | int | `` |  |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `false` |  |

--- a/charts/uptime-kuma/templates/service.yaml
+++ b/charts/uptime-kuma/templates/service.yaml
@@ -14,6 +14,9 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: 3001
       protocol: TCP
+      {{- with .Values.service.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
       name: http
   selector:
     {{- include "uptime-kuma.selectorLabels" . | nindent 4 }}

--- a/charts/uptime-kuma/values.yaml
+++ b/charts/uptime-kuma/values.yaml
@@ -48,6 +48,7 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 3001
+  nodePort:
   annotations: {}
 
 ingress:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Check if an open Issue exists that is solved by your changes.

 Thank you for contributing! I will try to test and integrate the change as soon as possible, but be aware that I can't immediately respond to every request.

 -->

**Description of the change**

This change allows the user to define a custom `nodePort` value for the service generated by this Helm Chart.
Setting this value only makes sense if the user set `service.type` to `NodePort`.

**Benefits**

Users that use a load balancer outside the cluster, can define a fixed node-port.

**Possible drawbacks**

None? :D

**Applicable issues**

N/A

**Additional information**

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
