### PR TITLE
Update livenessprobe healthcheck to upstream script

### DIFF
--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -11,4 +11,4 @@ name: uptime-kuma
 sources:
   - https://github.com/louislam/uptime-kuma
 type: application
-version: 2.5.6
+version: 2.6.6

--- a/charts/uptime-kuma/templates/deployment.yaml
+++ b/charts/uptime-kuma/templates/deployment.yaml
@@ -54,8 +54,7 @@ spec:
           livenessProbe:
             exec:
               command:
-                - node
-                - extra/healthcheck.js
+                - /healthcheck.sh
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds}}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds}}
           readinessProbe:


### PR DESCRIPTION
The livenessprobe is causing the container to quit even though its running correctly. The upstream image now contains /healthcheck.sh