### PR TITLE
add option to disable probes

### DIFF
--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -11,4 +11,4 @@ name: uptime-kuma
 sources:
   - https://github.com/louislam/uptime-kuma
 type: application
-version: 2.5.8
+version: 2.5.9

--- a/charts/uptime-kuma/README.md
+++ b/charts/uptime-kuma/README.md
@@ -39,6 +39,7 @@ A self-hosted Monitoring tool like "Uptime-Robot".
 | ingress.hosts[0].paths[0].path | string | `"/"` |  |
 | ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
 | ingress.tls | list | `[]` |  |
+| livenessProbe.enabled | bool | `true` |  |
 | livenessProbe.initialDelaySeconds | int | `15` |  |
 | livenessProbe.timeoutSeconds | int | `2` |  |
 | nameOverride | string | `""` |  |
@@ -47,7 +48,8 @@ A self-hosted Monitoring tool like "Uptime-Robot".
 | podEnv[0].name | string | `"UPTIME_KUMA_PORT"` |  |
 | podEnv[0].value | string | `"3001"` |  |
 | podLabels | object | `{}` |  |
-| podSecurityContext | object | `{}` |  |
+| podSecurityContext | object | `{}` |  |#
+| readinessProbe.enabled | bool | `true` |  |
 | readinessProbe.initialDelaySeconds | int | `5` |  |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |

--- a/charts/uptime-kuma/templates/deployment.yaml
+++ b/charts/uptime-kuma/templates/deployment.yaml
@@ -51,6 +51,7 @@ spec:
             - mountPath: /app/data
               name: storage
           {{ end }}
+          {{ if .Values.livenessProbe.enabled -}}
           livenessProbe:
             exec:
               command:
@@ -58,12 +59,15 @@ spec:
                 - extra/healthcheck.js
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds}}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds}}
+          {{ end }}  
+          {{ if .Values.readinessProbe.enabled -}}  
           readinessProbe:
             httpGet:
               path: /
               port: 3001
               scheme: HTTP
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds}}
+          {{ end }}  
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/uptime-kuma/values.yaml
+++ b/charts/uptime-kuma/values.yaml
@@ -111,10 +111,12 @@ tolerations: []
 affinity: {}
 
 livenessProbe:
+  enabled: true
   timeoutSeconds: 2
   initialDelaySeconds: 15
 
 readinessProbe:
+  enabled: true
   initialDelaySeconds: 5
 
 volume:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Check if an open Issue exists that is solved by your changes.

 Thank you for contributing! I will try to test and integrate the change as soon as possible, but be aware that I can't immediately respond to every request.

 -->

**Description of the change**

add enable flag to liveness and readiness probes. Default is set to be enabled.

**Benefits**

ability to disable probes for use in test environments 

**Possible drawbacks**


**Applicable issues**


**Additional information**

The liveness probe of my deployment fails for no apparent reason.  The application works just fine when I manually disable it. So I thought there should be an option in the Chart to do so, if one wants to run the application in a non critical environment where some downtime won't matter.

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
