### PR TITLE
(perf): use new healthcheck

### DIFF
--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -11,4 +11,4 @@ name: uptime-kuma
 sources:
   - https://github.com/louislam/uptime-kuma
 type: application
-version: 2.5.9
+version: 2.6.9

--- a/charts/uptime-kuma/templates/deployment.yaml
+++ b/charts/uptime-kuma/templates/deployment.yaml
@@ -55,8 +55,7 @@ spec:
           livenessProbe:
             exec:
               command:
-                - node
-                - extra/healthcheck.js
+                - extra/healthcheck
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds}}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds}}
           {{ end }}  

--- a/charts/uptime-kuma/templates/statefulset.yaml
+++ b/charts/uptime-kuma/templates/statefulset.yaml
@@ -58,8 +58,7 @@ spec:
           livenessProbe:
             exec:
               command:
-                - node
-                - extra/healthcheck.js
+                - extra/healthcheck
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds}}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds}}
           readinessProbe:


### PR DESCRIPTION
**Description of the change**

Use the new healthcheck binary introduced in https://github.com/louislam/uptime-kuma/pull/2374 instead of the js one

**Benefits**

Avoid CPU spikes due to node processes spawn (See https://github.com/louislam/uptime-kuma/issues/2249)

**Possible drawbacks**

none

**Applicable issues**

none

**Additional information**

none

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
