### PR TITLE
Removed misleading autoscaling option from the values and docs

### DIFF
--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -11,4 +11,4 @@ name: uptime-kuma
 sources:
   - https://github.com/louislam/uptime-kuma
 type: application
-version: 2.7.10
+version: 2.7.0

--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -11,4 +11,4 @@ name: uptime-kuma
 sources:
   - https://github.com/louislam/uptime-kuma
 type: application
-version: 2.7.0
+version: 2.8.0

--- a/charts/uptime-kuma/README.md
+++ b/charts/uptime-kuma/README.md
@@ -21,10 +21,6 @@ A self-hosted Monitoring tool like "Uptime-Robot".
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
-| autoscaling.enabled | bool | `false` |  |
-| autoscaling.maxReplicas | int | `10` |  |
-| autoscaling.minReplicas | int | `1` |  |
-| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"louislam/uptime-kuma"` |  |

--- a/charts/uptime-kuma/templates/deployment.yaml
+++ b/charts/uptime-kuma/templates/deployment.yaml
@@ -6,9 +6,7 @@ metadata:
   labels:
     {{- include "uptime-kuma.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
-  {{- end }}
   selector:
     matchLabels:
       {{- include "uptime-kuma.selectorLabels" . | nindent 6 }}

--- a/charts/uptime-kuma/templates/statefulset.yaml
+++ b/charts/uptime-kuma/templates/statefulset.yaml
@@ -7,9 +7,7 @@ metadata:
     {{- include "uptime-kuma.labels" . | nindent 4 }}
 spec:
   serviceName: {{ include "uptime-kuma.fullname" . }}
-  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
-  {{- end }}
   selector:
     matchLabels:
       {{- include "uptime-kuma.selectorLabels" . | nindent 6 }}

--- a/charts/uptime-kuma/values.yaml
+++ b/charts/uptime-kuma/values.yaml
@@ -97,13 +97,6 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
-autoscaling:
-  enabled: false
-  minReplicas: 1
-  maxReplicas: 10
-  targetCPUUtilizationPercentage: 80
-  # targetMemoryUtilizationPercentage: 80
-
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
**Description of the change**

This PR removes the autoscaling option from this chart.
The reason for it is, that it is unused => does not work

The reason for this is, that uptime-kuma currently does not scale to more than one instance. (local sqlite+ no multi-instance scheduling)
I would like to discuss if we should also remove the `replicas` option

**Benefits**

This removes a non-working/misleading option

**Possible drawbacks**

In future iterations of uptime kuma, this might be a thing that 

**Applicable issues**

/

**Additional information**

/

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
       ^- I would like to discuss on this one what you think this PR qualifies as: since this removes a non-working feature, I would qualify it as a bug-fix => patch increment? 
- [x] Variables are documented in the README.md
