### PR TITLE
Removed the `replicaCount` option

### DIFF
--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -11,4 +11,4 @@ name: uptime-kuma
 sources:
   - https://github.com/louislam/uptime-kuma
 type: application
-version: 2.8.1
+version: 2.9.1

--- a/charts/uptime-kuma/README.md
+++ b/charts/uptime-kuma/README.md
@@ -47,7 +47,6 @@ A self-hosted Monitoring tool like "Uptime-Robot".
 | podSecurityContext | object | `{}` |  |#
 | readinessProbe.enabled | bool | `true` |  |
 | readinessProbe.initialDelaySeconds | int | `5` |  |
-| replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |
 | service.annotations | object | `{}` |  |

--- a/charts/uptime-kuma/templates/deployment.yaml
+++ b/charts/uptime-kuma/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "uptime-kuma.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: 1
   selector:
     matchLabels:
       {{- include "uptime-kuma.selectorLabels" . | nindent 6 }}

--- a/charts/uptime-kuma/templates/statefulset.yaml
+++ b/charts/uptime-kuma/templates/statefulset.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "uptime-kuma.labels" . | nindent 4 }}
 spec:
   serviceName: {{ include "uptime-kuma.fullname" . }}
-  replicas: {{ .Values.replicaCount }}
+  replicas: 1
   selector:
     matchLabels:
       {{- include "uptime-kuma.selectorLabels" . | nindent 6 }}

--- a/charts/uptime-kuma/values.yaml
+++ b/charts/uptime-kuma/values.yaml
@@ -2,8 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
-
 image:
   repository: louislam/uptime-kuma
   pullPolicy: IfNotPresent


### PR DESCRIPTION
**Description of the change**

In #96 we discussed how `replicaCount` should work and came to the conclusion that this option is likely misleading.
This PR removes this option

**Benefits**

Currently `replicaCount` would create a duplicate of the app. Depending on if `useDeploy` is activated, this could have different consequences, but I dont see a way this has usefull sideeffects.
Until uptime-kuma supports sharding/..., this should not be a feature this we offer imo

**Possible drawbacks**

This feature might have to be reverted in the future, if `uptime-kuma` supports this someday (it is on the backlog, but it is unclear when this wil come to fruition)

**Applicable issues**

/

**Additional information**

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
