### PR TITLE
Update default strategy.type value

### DIFF
--- a/charts/uptime-kuma/values.yaml
+++ b/charts/uptime-kuma/values.yaml
@@ -143,7 +143,7 @@ additionalVolumeMounts:
   #   subPath: "additional-ca.pem"
 
 strategy:
-  type: Recreate
+  type: RollingUpdate
 
 # Prometheus ServiceMonitor configuration
 serviceMonitor:


### PR DESCRIPTION
**Description of the change**

This is a small change in the default value of the `strategy.type`.

**Benefits**

This change syncs with the default value of the Kubernetes deployments.

**Applicable issues**

  - fixes #133 

