### PR TITLE
Add support for loadBalancerIP

### DIFF
--- a/charts/uptime-kuma/README.md
+++ b/charts/uptime-kuma/README.md
@@ -71,6 +71,7 @@ A self-hosted Monitoring tool like "Uptime-Robot".
 | service.nodePort | string | `nil` |  |
 | service.port | int | `3001` |  |
 | service.type | string | `"ClusterIP"` |  |
+| service.loadBalancerIP | string | `""` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `false` |  |
 | serviceAccount.name | string | `""` |  |

--- a/charts/uptime-kuma/templates/service.yaml
+++ b/charts/uptime-kuma/templates/service.yaml
@@ -18,5 +18,8 @@ spec:
       nodePort: {{ . }}
       {{- end }}
       name: http
+{{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP | quote }}
+{{- end }}
   selector:
     {{- include "uptime-kuma.selectorLabels" . | nindent 4 }}

--- a/charts/uptime-kuma/values.yaml
+++ b/charts/uptime-kuma/values.yaml
@@ -51,6 +51,7 @@ service:
   port: 3001
   nodePort:
   annotations: {}
+  loadBalancerIP:
 
 ingress:
   enabled: false


### PR DESCRIPTION
Add `loadBalancerIP` field to `service.yaml`
closes #142