### PR TITLE
feat: make access mode configurable with default option

### DIFF
--- a/charts/uptime-kuma/templates/pvc.yaml
+++ b/charts/uptime-kuma/templates/pvc.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "uptime-kuma.labels" . | nindent 4 }}
 spec:
   accessModes:
-    - ReadWriteOnce
+    - {{ .Values.volume.accessMode | default "ReadWriteOnce" | quote }}
   resources:
     requests:
       storage: {{ .Values.volume.size | quote }}


### PR DESCRIPTION
**Description of the change**

It should be possible to set the pvc as rwx for instance. If no value has been set it will use rwo as default.

**Benefits**

Being able to deploy with rwx storage.

**Possible drawbacks**

Someone could configure it wrong but then he could just remove its custom value.

**Applicable issues**

Cluster with several worker and the willing to be able to deploy kuma on any, mostly for fault tolerance.

**Additional information**

Value was already documented as usable in README but is not. I didn’t upgrade version as this minor fix could be part of larger release.

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
