### PR TITLE
Add environment variable for using a custom CA (for the additional-certificates configMap to work) 

### DIFF
--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "1.23.13"
+appVersion: "1.23.14"
 deprecated: false
 description: A self-hosted Monitoring tool like "Uptime-Robot".
 home: https://github.com/dirsigler/uptime-kuma-helm

--- a/charts/uptime-kuma/README.md
+++ b/charts/uptime-kuma/README.md
@@ -51,6 +51,8 @@ A self-hosted Monitoring tool like "Uptime-Robot".
 | podAnnotations | object | `{}` |  |
 | podEnv[0].name | string | `"UPTIME_KUMA_PORT"` |  |
 | podEnv[0].value | string | `"3001"` |  |
+| podEnv[0].name | string | `"NODE_EXTRA_CA_CERTS"` |  |
+| podEnv[0].value | string | `"/etc/ssl/certs/additional/additional-ca.pem"` |  |
 | podLabels | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | readinessProbe.enabled | bool | `true` |  |

--- a/charts/uptime-kuma/values.yaml
+++ b/charts/uptime-kuma/values.yaml
@@ -32,6 +32,9 @@ podEnv:
   # a default port must be set. required by container
   - name: "UPTIME_KUMA_PORT"
     value: "3001"
+  # For using a custom CA with additionalVolumes, the CA must be passed as an env variable to node
+  # - name: "NODE_EXTRA_CA_CERTS"
+  #   value: "/etc/ssl/certs/additional/additional-ca.pem"
 
 podSecurityContext:
   {}


### PR DESCRIPTION
**Description of the change**

The current commented-out additionalVolumes example that loads in a configMap for supplying a custom enterprise root CA doesn't work on its own - we need to tell node to use it via a custom environment variable.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

Using a custom CA works fully with this.

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

N/A - we already have commented-out code for custom roots in the values.yaml default from Helm from this chart.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

N/A

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

N/A

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
