### PR TITLE
Add namespace template variable

### DIFF
--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -11,4 +11,4 @@ name: uptime-kuma
 sources:
   - https://github.com/louislam/uptime-kuma
 type: application
-version: 2.20.0
+version: 2.20.1

--- a/charts/uptime-kuma/README.md
+++ b/charts/uptime-kuma/README.md
@@ -47,6 +47,7 @@ A self-hosted Monitoring tool like "Uptime-Robot".
 | livenessProbe.successThreshold | int | `1` |  |
 | livenessProbe.timeoutSeconds | int | `2` |  |
 | nameOverride | string | `""` |  |
+| namespaceOverride | string | `""` | A custom namespace to override the default namespace for the deployed resources. |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
 | podEnv[0].name | string | `"UPTIME_KUMA_PORT"` |  |

--- a/charts/uptime-kuma/templates/_helpers.tpl
+++ b/charts/uptime-kuma/templates/_helpers.tpl
@@ -67,3 +67,14 @@ Set automountServiceAccountToken when service account is created
 {{- define "uptime-kuma.automountServiceAccountToken" -}}
 {{- default .Values.serviceAccount.create }}
 {{- end }}
+
+{{/*
+Determine the namespace to use, allowing for a namespace override.
+*/}}
+{{- define "uptime-kuma.namespace" -}}
+  {{- if .Values.namespaceOverride }}
+    {{- .Values.namespaceOverride }}
+  {{- else }}
+    {{- .Release.Namespace }}
+  {{- end }}
+{{- end }}

--- a/charts/uptime-kuma/templates/deployment.yaml
+++ b/charts/uptime-kuma/templates/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "uptime-kuma.fullname" . }}
+  namespace: {{ include "uptime-kuma.namespace" . }}
   labels:
     {{- include "uptime-kuma.labels" . | nindent 4 }}
 spec:

--- a/charts/uptime-kuma/templates/ingress.yaml
+++ b/charts/uptime-kuma/templates/ingress.yaml
@@ -16,6 +16,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ include "uptime-kuma.namespace" . }}
   labels:
     {{- include "uptime-kuma.labels" . | nindent 4 }}
     {{- if .Values.ingress.extraLabels }}

--- a/charts/uptime-kuma/templates/pvc.yaml
+++ b/charts/uptime-kuma/templates/pvc.yaml
@@ -4,6 +4,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ include "uptime-kuma.fullname" . }}-pvc
+  namespace: {{ include "uptime-kuma.namespace" . }}
   labels:
     {{- include "uptime-kuma.labels" . | nindent 4 }}
 spec:

--- a/charts/uptime-kuma/templates/service.yaml
+++ b/charts/uptime-kuma/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "uptime-kuma.fullname" . }}
+  namespace: {{ include "uptime-kuma.namespace" . }}
   labels:
     {{- include "uptime-kuma.labels" . | nindent 4 }}
   {{- with .Values.service.annotations }}

--- a/charts/uptime-kuma/templates/serviceaccount.yaml
+++ b/charts/uptime-kuma/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "uptime-kuma.serviceAccountName" . }}
+  namespace: {{ include "uptime-kuma.namespace" . }}
   labels:
     {{- include "uptime-kuma.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/uptime-kuma/templates/servicemonitor.auth.secret.yaml
+++ b/charts/uptime-kuma/templates/servicemonitor.auth.secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "uptime-kuma.fullname" . }}-metrics-basic-auth
-  namespace: {{ default .Release.Namespace .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace | default (include "uptime-kuma.namespace" .) }}
 type: kubernetes.io/basic-auth
 stringData:
 {{- range $key, $value := .Values.serviceMonitor.basicAuth }}

--- a/charts/uptime-kuma/templates/servicemonitor.yaml
+++ b/charts/uptime-kuma/templates/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "uptime-kuma.fullname" . }}
-  namespace: {{ default .Release.Namespace .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace | default (include "uptime-kuma.namespace" .) }}
   labels:
     {{- include "uptime-kuma.labels" . | nindent 4 }}
     {{- with .Values.serviceMonitor.selector }}

--- a/charts/uptime-kuma/templates/statefulset.yaml
+++ b/charts/uptime-kuma/templates/statefulset.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "uptime-kuma.fullname" . }}
+  namespace: {{ include "uptime-kuma.namespace" . }}
   labels:
     {{- include "uptime-kuma.labels" . | nindent 4 }}
 spec:

--- a/charts/uptime-kuma/templates/tests/test-connection.yaml
+++ b/charts/uptime-kuma/templates/tests/test-connection.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "uptime-kuma.fullname" . }}-test-connection"
+  namespace: {{ include "uptime-kuma.namespace" . }}
   labels:
     {{- include "uptime-kuma.labels" . | nindent 4 }}
   annotations:

--- a/charts/uptime-kuma/values.yaml
+++ b/charts/uptime-kuma/values.yaml
@@ -11,6 +11,7 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+# -- A custom namespace to override the default namespace for the deployed resources.
 namespaceOverride: ""
 
 # If this option is set to false a StateFulset instead of a Deployment is used

--- a/charts/uptime-kuma/values.yaml
+++ b/charts/uptime-kuma/values.yaml
@@ -11,6 +11,7 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+namespaceOverride: ""
 
 # If this option is set to false a StateFulset instead of a Deployment is used
 useDeploy: true


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Check if an open Issue exists that is solved by your changes.

 Thank you for contributing! I will try to test and integrate the change as soon as possible, but be aware that I can't immediately respond to every request.

 -->

**Description of the change**

- Added namespaceOverride template variable to support flexible namespace configurations.
- Introduced helper function in helpers.tpl for namespace resolution.
- Updated relevant templates to utilize the new namespace logic.
- Bumped Helm chart version to 2.21.0.

**Benefits**

When using [cdk8s](https://cdk8s.io/docs/latest/), you can't scope your resources to a namespace unless the Helm chart has a template variable for that. 

**Possible drawbacks**

None that come to mind.

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
