### PR TITLE
fix parsing UPTIME_KUMA_PORT value when applying with serverSide enabled

### DIFF
--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -11,4 +11,4 @@ name: uptime-kuma
 sources:
   - https://github.com/louislam/uptime-kuma
 type: application
-version: 2.21.0
+version: 2.21.1

--- a/charts/uptime-kuma/templates/statefulset.yaml
+++ b/charts/uptime-kuma/templates/statefulset.yaml
@@ -53,7 +53,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: "UPTIME_KUMA_PORT"
-              value: {{ include "uptime-kuma.port" . }}
+              value: {{ include "uptime-kuma.port" . | quote }}
           {{- with .Values.podEnv }}
             {{- toYaml . | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
Fixes https://github.com/dirsigler/uptime-kuma-helm/issues/184

I tested it getting the **manifests.yaml** with the default values but setting `useDeploy: false`

before:

- `kubectl apply -f manifests.yaml --dry-run=server`

```
Error from server (BadRequest): error when creating "manifests.yaml": StatefulSet in version "v1" cannot be handled as a StatefulSet: json: cannot unmarshal number into Go struct field EnvVar.spec.template.spec.containers.env.value of type string
```

after:

- `kubectl apply -f manifests.yaml --dry-run=server`

```
statefulset.apps/test-uptime-kuma created (server dry run)
```

