### PR TITLE
Add MariaDB support for Uptime-Kuma v2

### DIFF
--- a/.github/configs/ct.yaml
+++ b/.github/configs/ct.yaml
@@ -4,4 +4,5 @@ chart-dirs:
   - charts
 chart-repos:
   - uptime-kuma=https://dirsigler.github.io/uptime-kuma-helm
+  - bitnami=https://charts.bitnami.com/bitnami
 debug: true

--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -10,5 +10,10 @@ maintainers:
 name: uptime-kuma
 sources:
   - https://github.com/louislam/uptime-kuma
+dependencies:
+  - name: mariadb
+    version: 20.2.2
+    repository: https://charts.bitnami.com/bitnami
+    condition: mariadb.enabled
 type: application
-version: 2.21.2
+version: 2.21.3

--- a/charts/uptime-kuma/README.md
+++ b/charts/uptime-kuma/README.md
@@ -20,7 +20,7 @@ A self-hosted Monitoring tool like "Uptime-Robot".
 
 To use MariaDB as the database backend for the application, set `mariadb.enabled=true`
 
-For more advanced configuration options (e.g., setting up replication, customizing storage), refer to the official [https://artifacthub.io/packages/helm/bitnami/mariadb](Bitnami MariaDB Helm chart documentation).
+For more advanced configuration options (e.g., setting up replication, customizing storage), refer to the official [Bitnami MariaDB Helm chart documentation](https://artifacthub.io/packages/helm/bitnami/mariadb).
 
 ## Values
 

--- a/charts/uptime-kuma/README.md
+++ b/charts/uptime-kuma/README.md
@@ -16,6 +16,12 @@ A self-hosted Monitoring tool like "Uptime-Robot".
 
 * <https://github.com/louislam/uptime-kuma>
 
+## MariaDB Configuration
+
+To use MariaDB as the database backend for the application, set `mariadb.enabled=true`
+
+For more advanced configuration options (e.g., setting up replication, customizing storage), refer to the official [https://artifacthub.io/packages/helm/bitnami/mariadb](Bitnami MariaDB Helm chart documentation).
+
 ## Values
 
 | Key | Type | Default | Description |
@@ -46,6 +52,12 @@ A self-hosted Monitoring tool like "Uptime-Robot".
 | livenessProbe.periodSeconds | int | `10` |  |
 | livenessProbe.successThreshold | int | `1` |  |
 | livenessProbe.timeoutSeconds | int | `2` |  |
+| mariadb.enabled | bool | `false` | Whether to enable MariaDB as the database backend. |
+| mariadb.architecture | str | `standalone` | |
+| mariadb.auth.database | str | `uptime_kuma` | |
+| mariadb.auth.username | str | `uptime_kuma` | |
+| mariadb.auth.password | str | `""` | |
+| mariadb.auth.rootPassword | str | `""` | |
 | nameOverride | string | `""` |  |
 | namespaceOverride | string | `""` | A custom namespace to override the default namespace for the deployed resources. |
 | networkPolicy | object | `{"allowExternal":true,"egress":true,"enabled":false,"ingress":true,"namespaceSelector":{}}` | Create a NetworkPolicy |

--- a/charts/uptime-kuma/templates/deployment.yaml
+++ b/charts/uptime-kuma/templates/deployment.yaml
@@ -54,10 +54,27 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- with .Values.podEnv }}
           env:
+            {{- with .Values.podEnv }}
             {{- toYaml . | nindent 12 }}
-          {{- end }}
+            {{- end }}
+            {{- if .Values.mariadb.enabled }}
+            - name: UPTIME_KUMA_DB_TYPE
+              value: "mariadb"
+            - name: UPTIME_KUMA_DB_HOSTNAME
+              value: "{{ .Release.Name }}-mariadb"
+            - name: UPTIME_KUMA_DB_PORT
+              value: "3306"
+            - name: UPTIME_KUMA_DB_NAME
+              value: "{{ .Values.mariadb.auth.database }}"
+            - name: UPTIME_KUMA_DB_USERNAME
+              value: "{{ .Values.mariadb.auth.username }}"
+            - name: UPTIME_KUMA_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Release.Name }}-mariadb"
+                  key: "mariadb-password"
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ include "uptime-kuma.port" . }}
@@ -111,6 +128,22 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- if .Values.mariadb.enabled }}
+      initContainers:
+        - name: wait-for-db
+          image: busybox:latest
+          command:
+            - "/bin/sh"
+            - "-c"
+            - "until nc -z {{ .Release.Name }}-mariadb 3306; do echo 'Waiting for MariaDB...'; sleep 2; done; echo 'MariaDB is ready!'"
+          resources:
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+            requests:
+              memory: "32Mi"
+              cpu: "50m"
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/uptime-kuma/templates/statefulset.yaml
+++ b/charts/uptime-kuma/templates/statefulset.yaml
@@ -58,6 +58,23 @@ spec:
           {{- with .Values.podEnv }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if .Values.mariadb.enabled }}
+            - name: UPTIME_KUMA_DB_TYPE
+              value: "mariadb"
+            - name: UPTIME_KUMA_DB_HOSTNAME
+              value: "{{ .Release.Name }}-mariadb"
+            - name: UPTIME_KUMA_DB_PORT
+              value: "3306"
+            - name: UPTIME_KUMA_DB_NAME
+              value: "{{ .Values.mariadb.auth.database }}"
+            - name: UPTIME_KUMA_DB_USERNAME
+              value: "{{ .Values.mariadb.auth.username }}"
+            - name: UPTIME_KUMA_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Release.Name }}-mariadb"
+                  key: "mariadb-password"
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ include "uptime-kuma.port" . }}

--- a/charts/uptime-kuma/values.yaml
+++ b/charts/uptime-kuma/values.yaml
@@ -168,6 +168,16 @@ additionalVolumeMounts:
 strategy:
   type: Recreate
 
+# Mariadb configurations
+mariadb:
+  enabled: false
+  architecture: standalone
+  auth:
+    database: uptime_kuma
+    username: uptime_kuma
+    password: ""
+    rootPassword: ""
+
 # Prometheus ServiceMonitor configuration
 serviceMonitor:
   enabled: false


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Check if an open Issue exists that is solved by your changes.

 Thank you for contributing! I will try to test and integrate the change as soon as possible, but be aware that I can't immediately respond to every request.

 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

This PR adds support for using MariaDB as a database backend for Uptime-Kuma using Bitnami's chart. Currently in beta, this feature allows users to choose between the default SQLite or MariaDB for storing Uptime-Kuma data. MariaDB support includes environment variable configuration, secret handling for database credentials, and persistence options for MariaDB data.

**Benefits**

<!-- What benefits will be realized by the code change? -->

Provides the option to use MariaDB instead of SQLite for a more scalable database backend.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

- MariaDB support in Uptime-Kuma is still in beta. This chart was tested with `2.0.0-beta.1`.
- This update is designed to be backward-compatible with existing database configurations.

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
