### PR TITLE
Add support for external database configuration + fix statefulset

### DIFF
--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -16,4 +16,4 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     condition: mariadb.enabled
 type: application
-version: 2.22.0
+version: 2.22.1

--- a/charts/uptime-kuma/README.md
+++ b/charts/uptime-kuma/README.md
@@ -31,6 +31,15 @@ A self-hosted Monitoring tool like "Uptime-Robot".
 | affinity | object | `{}` |  |
 | dnsConfig | object | `{}` | Use this option to set custom DNS configurations to the created deployment |
 | dnsPolicy | string | `""` | Use this option to set a custom DNS policy to the created deployment |
+| externalDatabase.database | string | `"uptime_kuma"` |  |
+| externalDatabase.enabled | bool | `false` |  |
+| externalDatabase.existingSecret | string | `""` |  |
+| externalDatabase.existingSecretPasswordKey | string | `"password"` |  |
+| externalDatabase.existingSecretUsernameKey | string | `"username"` |  |
+| externalDatabase.hostname | string | `""` |  |
+| externalDatabase.password | string | `""` |  |
+| externalDatabase.port | int | `3306` |  |
+| externalDatabase.username | string | `"uptime_kuma"` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"louislam/uptime-kuma"` |  |

--- a/charts/uptime-kuma/templates/_helpers.tpl
+++ b/charts/uptime-kuma/templates/_helpers.tpl
@@ -85,3 +85,12 @@ Determine the namespace to use, allowing for a namespace override.
     {{- .Release.Namespace }}
   {{- end }}
 {{- end }}
+
+{{/*
+Validate configuration for conflicting settings
+*/}}
+{{- define "uptime-kuma.validateDbConfig" -}}
+{{- if and .Values.mariadb.enabled .Values.externalDatabase.enabled }}
+{{- fail "Cannot enable both MariaDB (.Values.mariadb.enabled) and external database (.Values.externalDatabase.enabled). Please choose one." }}
+{{- end }}
+{{- end }}

--- a/charts/uptime-kuma/templates/deployment.yaml
+++ b/charts/uptime-kuma/templates/deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.useDeploy -}}
+{{- include "uptime-kuma.validateDbConfig" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -74,6 +75,33 @@ spec:
                 secretKeyRef:
                   name: "{{ .Release.Name }}-mariadb"
                   key: "mariadb-password"
+            {{- else if .Values.externalDatabase.enabled }}
+            - name: UPTIME_KUMA_DB_TYPE
+              value: "mariadb"
+            - name: UPTIME_KUMA_DB_HOSTNAME
+              value: "{{ .Values.externalDatabase.hostname }}"
+            - name: UPTIME_KUMA_DB_PORT
+              value: "{{ .Values.externalDatabase.port }}"
+            - name: UPTIME_KUMA_DB_NAME
+              value: "{{ .Values.externalDatabase.database }}"
+            - name: UPTIME_KUMA_DB_USERNAME
+              {{- if .Values.externalDatabase.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.externalDatabase.existingSecret }}"
+                  key: "{{ .Values.externalDatabase.existingSecretUsernameKey }}"
+              {{- else }}
+              value: "{{ .Values.externalDatabase.username }}"
+              {{- end }}
+            - name: UPTIME_KUMA_DB_PASSWORD
+              {{- if .Values.externalDatabase.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.externalDatabase.existingSecret }}"
+                  key: "{{ .Values.externalDatabase.existingSecretPasswordKey }}"
+              {{- else }}
+              value: "{{ .Values.externalDatabase.password }}"
+              {{- end }}
             {{- end }}
           ports:
             - name: http

--- a/charts/uptime-kuma/templates/statefulset.yaml
+++ b/charts/uptime-kuma/templates/statefulset.yaml
@@ -1,4 +1,5 @@
 {{- if not .Values.useDeploy -}}
+{{- include "uptime-kuma.validateDbConfig" . -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -9,6 +10,10 @@ metadata:
 spec:
   serviceName: {{ include "uptime-kuma.fullname" . }}
   replicas: 1
+  {{- with .Values.strategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "uptime-kuma.selectorLabels" . | nindent 6 }}
@@ -55,10 +60,10 @@ spec:
           env:
             - name: "UPTIME_KUMA_PORT"
               value: {{ include "uptime-kuma.port" . | quote }}
-          {{- with .Values.podEnv }}
+            {{- with .Values.podEnv }}
             {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- if .Values.mariadb.enabled }}
+            {{- end }}
+            {{- if .Values.mariadb.enabled }}
             - name: UPTIME_KUMA_DB_TYPE
               value: "mariadb"
             - name: UPTIME_KUMA_DB_HOSTNAME
@@ -74,6 +79,33 @@ spec:
                 secretKeyRef:
                   name: "{{ .Release.Name }}-mariadb"
                   key: "mariadb-password"
+            {{- else if .Values.externalDatabase.enabled }}
+            - name: UPTIME_KUMA_DB_TYPE
+              value: "mariadb"
+            - name: UPTIME_KUMA_DB_HOSTNAME
+              value: "{{ .Values.externalDatabase.hostname }}"
+            - name: UPTIME_KUMA_DB_PORT
+              value: "{{ .Values.externalDatabase.port }}"
+            - name: UPTIME_KUMA_DB_NAME
+              value: "{{ .Values.externalDatabase.database }}"
+            - name: UPTIME_KUMA_DB_USERNAME
+              {{- if .Values.externalDatabase.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.externalDatabase.existingSecret }}"
+                  key: "{{ .Values.externalDatabase.existingSecretUsernameKey }}"
+              {{- else }}
+              value: "{{ .Values.externalDatabase.username }}"
+              {{- end }}
+            - name: UPTIME_KUMA_DB_PASSWORD
+              {{- if .Values.externalDatabase.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.externalDatabase.existingSecret }}"
+                  key: "{{ .Values.externalDatabase.existingSecretPasswordKey }}"
+              {{- else }}
+              value: "{{ .Values.externalDatabase.password }}"
+              {{- end }}
             {{- end }}
           ports:
             - name: http
@@ -91,22 +123,59 @@ spec:
           {{- end }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
+            {{- if .Values.livenessProbe.enabled }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            {{- if .Values.livenessProbe.exec.command }}
             exec:
               command:
-                - extra/healthcheck
-            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds}}
-            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds}}
+                {{- toYaml .Values.livenessProbe.exec.command | nindent 16 }}
+            {{- end }}
+            {{- end }}
           {{- end }}
-          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
+            {{- if .Values.readinessProbe.enabled }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            {{- if .Values.readinessProbe.exec.command }}
+            exec:
+              command:
+                {{- toYaml .Values.readinessProbe.exec.command | nindent 16 }}
+            {{- else if .Values.readinessProbe.httpGet.path }}
             httpGet:
-              path: /
-              port: {{ include "uptime-kuma.port" . }}
-              scheme: HTTP
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds}}
-          {{- end }}
+              path: {{ .Values.readinessProbe.httpGet.path }}
+              port: {{ .Values.readinessProbe.httpGet.port }}
+              scheme: {{ .Values.readinessProbe.httpGet.scheme }}
+              {{- if .Values.readinessProbe.httpGet.httpHeaders }}
+              httpHeaders:
+                {{- toYaml .Values.readinessProbe.httpGet.httpHeaders | nindent 16 }}
+              {{- end }}
+            {{- end }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- if .Values.mariadb.enabled }}
+      initContainers:
+        - name: wait-for-db
+          image: busybox:latest
+          command:
+            - "/bin/sh"
+            - "-c"
+            - "until nc -z {{ .Release.Name }}-mariadb 3306; do echo 'Waiting for MariaDB...'; sleep 2; done; echo 'MariaDB is ready!'"
+          resources:
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+            requests:
+              memory: "32Mi"
+              cpu: "50m"
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/uptime-kuma/tests/deployment_test.yaml
+++ b/charts/uptime-kuma/tests/deployment_test.yaml
@@ -1,0 +1,214 @@
+suite: test deployment
+templates:
+  - deployment.yaml
+tests:
+  - it: should create deployment when useDeploy is true
+    set:
+      useDeploy: true
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-uptime-kuma
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: should not create deployment when useDeploy is false
+    set:
+      useDeploy: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should set correct image
+    set:
+      useDeploy: true
+      image:
+        repository: louislam/uptime-kuma
+        tag: "1.23.16-debian"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "louislam/uptime-kuma:1.23.16-debian"
+
+  - it: should configure MariaDB environment variables when enabled
+    set:
+      useDeploy: true
+      mariadb:
+        enabled: true
+        auth:
+          database: uptime_kuma
+          username: uptime_kuma
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: UPTIME_KUMA_DB_TYPE
+            value: "mariadb"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: UPTIME_KUMA_DB_HOSTNAME
+            value: "RELEASE-NAME-mariadb"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: UPTIME_KUMA_DB_NAME
+            value: "uptime_kuma"
+
+  - it: should configure external database environment variables when enabled
+    set:
+      useDeploy: true
+      externalDatabase:
+        enabled: true
+        hostname: "external-db.example.com"
+        port: 3306
+        database: uptime_kuma
+        username: uptime_kuma
+        password: "secret"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: UPTIME_KUMA_DB_TYPE
+            value: "mariadb"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: UPTIME_KUMA_DB_HOSTNAME
+            value: "external-db.example.com"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: UPTIME_KUMA_DB_PORT
+            value: "3306"
+
+  - it: should use existing secret for external database
+    set:
+      useDeploy: true
+      externalDatabase:
+        enabled: true
+        hostname: "external-db.example.com"
+        existingSecret: "my-db-secret"
+        existingSecretPasswordKey: "password"
+        existingSecretUsernameKey: "username"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: UPTIME_KUMA_DB_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: "my-db-secret"
+                key: "username"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: UPTIME_KUMA_DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: "my-db-secret"
+                key: "password"
+
+  - it: should create init container when MariaDB is enabled
+    set:
+      useDeploy: true
+      mariadb:
+        enabled: true
+    asserts:
+      - isNotEmpty:
+          path: spec.template.spec.initContainers
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-for-db
+
+  - it: should configure volume mounts when volume is enabled
+    set:
+      useDeploy: true
+      volume:
+        enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: storage
+            mountPath: /app/data
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: storage
+            persistentVolumeClaim:
+              claimName: RELEASE-NAME-uptime-kuma-pvc
+
+  - it: should set resource limits and requests
+    set:
+      useDeploy: true
+      resources:
+        limits:
+          cpu: 100m
+          memory: 128Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 100m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 128Mi
+
+  - it: should configure strategy when specified
+    set:
+      useDeploy: true
+      strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          partition: 0
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+      - equal:
+          path: spec.strategy.rollingUpdate.partition
+          value: 0
+
+  - it: should configure liveness probe when enabled
+    set:
+      useDeploy: true
+      livenessProbe:
+        enabled: true
+        initialDelaySeconds: 180
+        periodSeconds: 10
+        timeoutSeconds: 2
+        failureThreshold: 3
+        successThreshold: 1
+        exec:
+          command:
+            - "extra/healthcheck"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
+          value: 180
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command[0]
+          value: "extra/healthcheck"
+
+  - it: should configure readiness probe
+    set:
+      useDeploy: true
+      readinessProbe:
+        enabled: true
+        httpGet:
+          path: /
+          port: 3001
+          scheme: HTTP
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 3001

--- a/charts/uptime-kuma/tests/ingress_test.yaml
+++ b/charts/uptime-kuma/tests/ingress_test.yaml
@@ -1,0 +1,133 @@
+suite: test ingress
+templates:
+  - ingress.yaml
+tests:
+  - it: should create ingress when enabled
+    set:
+      ingress:
+        enabled: true
+        hosts:
+          - host: uptime-kuma.example.com
+            paths:
+              - path: /
+                pathType: ImplementationSpecific
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-uptime-kuma
+      - equal:
+          path: spec.rules[0].host
+          value: uptime-kuma.example.com
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /
+
+  - it: should not create ingress when disabled
+    set:
+      ingress:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should set ingress annotations
+    set:
+      ingress:
+        enabled: true
+        annotations:
+          nginx.ingress.kubernetes.io/rewrite-target: /
+          cert-manager.io/cluster-issuer: letsencrypt-prod
+        hosts:
+          - host: uptime-kuma.example.com
+            paths:
+              - path: /
+                pathType: Prefix
+    asserts:
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/rewrite-target"]
+          value: /
+      - equal:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+          value: letsencrypt-prod
+
+  - it: should configure TLS when specified
+    set:
+      ingress:
+        enabled: true
+        hosts:
+          - host: uptime-kuma.example.com
+            paths:
+              - path: /
+                pathType: Prefix
+        tls:
+          - secretName: uptime-kuma-tls
+            hosts:
+              - uptime-kuma.example.com
+    asserts:
+      - equal:
+          path: spec.tls[0].secretName
+          value: uptime-kuma-tls
+      - contains:
+          path: spec.tls[0].hosts
+          content: uptime-kuma.example.com
+
+  - it: should set custom ingress class
+    set:
+      ingress:
+        enabled: true
+        className: "nginx"
+        hosts:
+          - host: uptime-kuma.example.com
+            paths:
+              - path: /
+                pathType: Prefix
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: "nginx"
+
+  - it: should add extra labels
+    set:
+      ingress:
+        enabled: true
+        extraLabels:
+          environment: production
+          team: monitoring
+        hosts:
+          - host: uptime-kuma.example.com
+            paths:
+              - path: /
+                pathType: Prefix
+    asserts:
+      - equal:
+          path: metadata.labels.environment
+          value: production
+      - equal:
+          path: metadata.labels.team
+          value: monitoring
+
+  - it: should handle multiple hosts
+    set:
+      ingress:
+        enabled: true
+        hosts:
+          - host: uptime-kuma.example.com
+            paths:
+              - path: /
+                pathType: Prefix
+          - host: monitoring.example.com
+            paths:
+              - path: /uptime
+                pathType: Prefix
+    asserts:
+      - equal:
+          path: spec.rules[0].host
+          value: uptime-kuma.example.com
+      - equal:
+          path: spec.rules[1].host
+          value: monitoring.example.com
+      - equal:
+          path: spec.rules[1].http.paths[0].path
+          value: /uptime

--- a/charts/uptime-kuma/tests/pvc_test.yaml
+++ b/charts/uptime-kuma/tests/pvc_test.yaml
@@ -1,0 +1,70 @@
+suite: test pvc
+templates:
+  - pvc.yaml
+tests:
+  - it: should create PVC when volume is enabled
+    set:
+      volume:
+        enabled: true
+        size: 4Gi
+        accessMode: ReadWriteOnce
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-uptime-kuma-pvc
+      - equal:
+          path: spec.resources.requests.storage
+          value: 4Gi
+      - contains:
+          path: spec.accessModes
+          content: ReadWriteOnce
+
+  - it: should not create PVC when volume is disabled
+    set:
+      volume:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create PVC when existingClaim is set
+    set:
+      volume:
+        enabled: true
+        existingClaim: "my-existing-pvc"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should set custom storage class
+    set:
+      volume:
+        enabled: true
+        size: 8Gi
+        storageClassName: "fast-ssd"
+    asserts:
+      - equal:
+          path: spec.storageClassName
+          value: "fast-ssd"
+
+  - it: should set custom access mode
+    set:
+      volume:
+        enabled: true
+        accessMode: ReadWriteMany
+    asserts:
+      - contains:
+          path: spec.accessModes
+          content: ReadWriteMany
+
+  - it: should be in correct namespace
+    set:
+      volume:
+        enabled: true
+      namespaceOverride: "monitoring"
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: monitoring

--- a/charts/uptime-kuma/tests/service_test.yaml
+++ b/charts/uptime-kuma/tests/service_test.yaml
@@ -1,0 +1,89 @@
+suite: test service
+templates:
+  - service.yaml
+tests:
+  - it: should create service with default values
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-uptime-kuma
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: spec.ports[0].port
+          value: 3001
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 3001
+      - equal:
+          path: spec.ports[0].protocol
+          value: TCP
+
+  - it: should set NodePort service type
+    set:
+      service:
+        type: NodePort
+        nodePort: 30001
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30001
+
+  - it: should set LoadBalancer service type
+    set:
+      service:
+        type: LoadBalancer
+        port: 8080
+    asserts:
+      - equal:
+          path: spec.type
+          value: LoadBalancer
+      - equal:
+          path: spec.ports[0].port
+          value: 8080
+
+  - it: should add service annotations
+    set:
+      service:
+        annotations:
+          service.beta.kubernetes.io/aws-load-balancer-type: nlb
+          service.beta.kubernetes.io/aws-load-balancer-scheme: internal
+    asserts:
+      - equal:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-type"]
+          value: nlb
+      - equal:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-scheme"]
+          value: internal
+
+  - it: should have correct selector labels
+    asserts:
+      - equal:
+          path: spec.selector["app.kubernetes.io/name"]
+          value: uptime-kuma
+      - equal:
+          path: spec.selector["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+
+  - it: should use custom port
+    set:
+      service:
+        port: 9090
+    asserts:
+      - equal:
+          path: spec.ports[0].port
+          value: 9090
+
+  - it: should be in correct namespace
+    set:
+      namespaceOverride: "monitoring"
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: monitoring

--- a/charts/uptime-kuma/tests/serviceaccount_test.yaml
+++ b/charts/uptime-kuma/tests/serviceaccount_test.yaml
@@ -1,0 +1,57 @@
+suite: test serviceaccount
+templates:
+  - serviceaccount.yaml
+tests:
+  - it: should create service account when create is true
+    set:
+      serviceAccount:
+        create: true
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-uptime-kuma
+
+  - it: should not create service account when create is false
+    set:
+      serviceAccount:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should use custom service account name
+    set:
+      serviceAccount:
+        create: true
+        name: "custom-sa"
+    asserts:
+      - equal:
+          path: metadata.name
+          value: "custom-sa"
+
+  - it: should add annotations to service account
+    set:
+      serviceAccount:
+        create: true
+        annotations:
+          eks.amazonaws.com/role-arn: "arn:aws:iam::123456789012:role/uptime-kuma-role"
+          kubernetes.io/service-account.name: "uptime-kuma"
+    asserts:
+      - equal:
+          path: metadata.annotations["eks.amazonaws.com/role-arn"]
+          value: "arn:aws:iam::123456789012:role/uptime-kuma-role"
+      - equal:
+          path: metadata.annotations["kubernetes.io/service-account.name"]
+          value: "uptime-kuma"
+
+  - it: should be in correct namespace
+    set:
+      serviceAccount:
+        create: true
+      namespaceOverride: "monitoring"
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: monitoring

--- a/charts/uptime-kuma/tests/statefulset_test.yaml
+++ b/charts/uptime-kuma/tests/statefulset_test.yaml
@@ -1,0 +1,245 @@
+suite: test statefulset
+templates:
+  - statefulset.yaml
+tests:
+  - it: should create statefulset when useDeploy is false
+    set:
+      useDeploy: false
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-uptime-kuma
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: should not create statefulset when useDeploy is true
+    set:
+      useDeploy: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should set correct image
+    set:
+      useDeploy: false
+      image:
+        repository: louislam/uptime-kuma
+        tag: "1.23.16-debian"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "louislam/uptime-kuma:1.23.16-debian"
+
+  - it: should configure MariaDB environment variables when enabled
+    set:
+      useDeploy: false
+      mariadb:
+        enabled: true
+        auth:
+          database: uptime_kuma
+          username: uptime_kuma
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: UPTIME_KUMA_DB_TYPE
+            value: "mariadb"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: UPTIME_KUMA_DB_HOSTNAME
+            value: "RELEASE-NAME-mariadb"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: UPTIME_KUMA_DB_NAME
+            value: "uptime_kuma"
+
+  - it: should configure external database environment variables when enabled
+    set:
+      useDeploy: false
+      externalDatabase:
+        enabled: true
+        hostname: "external-db.example.com"
+        port: 3306
+        database: uptime_kuma
+        username: uptime_kuma
+        password: "secret"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: UPTIME_KUMA_DB_TYPE
+            value: "mariadb"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: UPTIME_KUMA_DB_HOSTNAME
+            value: "external-db.example.com"
+
+  - it: should configure volume claim template when volume is enabled
+    set:
+      useDeploy: false
+      volume:
+        enabled: true
+        size: 4Gi
+        accessMode: ReadWriteOnce
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: storage
+            mountPath: /app/data
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.name
+          value: storage
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
+          value: 4Gi
+
+  - it: should create init container when MariaDB is enabled
+    set:
+      useDeploy: false
+      mariadb:
+        enabled: true
+    asserts:
+      - isNotEmpty:
+          path: spec.template.spec.initContainers
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-for-db
+
+  - it: should configure service name
+    set:
+      useDeploy: false
+    asserts:
+      - equal:
+          path: spec.serviceName
+          value: RELEASE-NAME-uptime-kuma
+
+  - it: should set resource limits and requests
+    set:
+      useDeploy: false
+      resources:
+        limits:
+          cpu: 100m
+          memory: 128Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 100m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 128Mi
+
+  - it: should always set UPTIME_KUMA_PORT environment variable
+    set:
+      useDeploy: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: "UPTIME_KUMA_PORT"
+            value: "3001"
+
+  - it: should configure strategy when specified
+    set:
+      useDeploy: false
+      strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          partition: 0
+    asserts:
+      - equal:
+          path: spec.updateStrategy.type
+          value: RollingUpdate
+      - equal:
+          path: spec.updateStrategy.rollingUpdate.partition
+          value: 0
+
+  - it: should configure configurable liveness probe parameters
+    set:
+      useDeploy: false
+      livenessProbe:
+        enabled: true
+        initialDelaySeconds: 60
+        periodSeconds: 10
+        timeoutSeconds: 5
+        failureThreshold: 6
+        successThreshold: 1
+        exec:
+          command:
+            - extra/healthcheck
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
+          value: 60
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.periodSeconds
+          value: 10
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.timeoutSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.failureThreshold
+          value: 6
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.successThreshold
+          value: 1
+      - contains:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command
+          content: extra/healthcheck
+
+  - it: should configure configurable readiness probe parameters
+    set:
+      useDeploy: false
+      readinessProbe:
+        enabled: true
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        timeoutSeconds: 3
+        failureThreshold: 3
+        successThreshold: 1
+        httpGet:
+          path: /
+          port: 3001
+          scheme: HTTP
+          httpHeaders:
+            - name: Host
+              value: example.com
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
+          value: 30
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.periodSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.timeoutSeconds
+          value: 3
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.failureThreshold
+          value: 3
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.successThreshold
+          value: 1
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 3001
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
+          value: HTTP
+      - contains:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.httpHeaders
+          content:
+            name: Host
+            value: example.com

--- a/charts/uptime-kuma/tests/values_test.yaml
+++ b/charts/uptime-kuma/tests/values_test.yaml
@@ -1,0 +1,173 @@
+suite: test values validation
+templates:
+  - deployment.yaml
+  - statefulset.yaml
+  - service.yaml
+  - ingress.yaml
+  - pvc.yaml
+  - serviceaccount.yaml
+tests:
+  - it: should fail when both mariadb and externalDatabase are enabled
+    set:
+      useDeploy: true
+      mariadb:
+        enabled: true
+      externalDatabase:
+        enabled: true
+    templates:
+      - deployment.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "Cannot enable both MariaDB (.Values.mariadb.enabled) and external database (.Values.externalDatabase.enabled). Please choose one."
+
+  - it: should create ingress when enabled
+    set:
+      ingress:
+        enabled: true
+        hosts:
+          - host: uptime-kuma.example.com
+            paths:
+              - path: /
+                pathType: Prefix
+    templates:
+      - ingress.yaml
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: spec.rules[0].host
+          value: uptime-kuma.example.com
+
+  - it: should not create ingress when disabled
+    set:
+      ingress:
+        enabled: false
+    templates:
+      - ingress.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create PVC when volume is enabled and no existingClaim
+    set:
+      volume:
+        enabled: true
+        size: 8Gi
+        storageClassName: "fast-ssd"
+    templates:
+      - pvc.yaml
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: spec.resources.requests.storage
+          value: 8Gi
+      - equal:
+          path: spec.storageClassName
+          value: "fast-ssd"
+
+  - it: should not create PVC when existingClaim is set
+    set:
+      volume:
+        enabled: true
+        existingClaim: "my-existing-pvc"
+    templates:
+      - pvc.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create PVC when volume is disabled
+    set:
+      volume:
+        enabled: false
+    templates:
+      - pvc.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should validate image tag format in deployment
+    set:
+      useDeploy: true
+      image:
+        tag: "invalid-tag-format"
+    templates:
+      - deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "louislam/uptime-kuma:invalid-tag-format"
+
+  - it: should use chart appVersion when no tag specified in deployment
+    set:
+      useDeploy: true
+      image:
+        tag: ""
+    templates:
+      - deployment.yaml
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "louislam/uptime-kuma:[0-9]+\\.[0-9]+\\.[0-9]+"
+
+  - it: should configure serviceAccount when create is true
+    set:
+      serviceAccount:
+        create: true
+        name: "custom-sa"
+    templates:
+      - serviceaccount.yaml
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: "custom-sa"
+
+  - it: should set correct security context in deployment
+    set:
+      useDeploy: true
+      podSecurityContext:
+        fsGroup: 2000
+        runAsUser: 1000
+      securityContext:
+        runAsNonRoot: true
+        readOnlyRootFilesystem: true
+    templates:
+      - deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 2000
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+
+  - it: should add additional environment variables in deployment
+    set:
+      useDeploy: true
+      podEnv:
+        - name: "CUSTOM_VAR"
+          value: "custom-value"
+        - name: "ANOTHER_VAR"
+          valueFrom:
+            secretKeyRef:
+              name: "my-secret"
+              key: "secret-key"
+    templates:
+      - deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: "CUSTOM_VAR"
+            value: "custom-value"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: "ANOTHER_VAR"
+            valueFrom:
+              secretKeyRef:
+                name: "my-secret"
+                key: "secret-key"

--- a/charts/uptime-kuma/values.yaml
+++ b/charts/uptime-kuma/values.yaml
@@ -178,6 +178,20 @@ mariadb:
     password: ""
     rootPassword: ""
 
+# External MariaDB database configuration
+# Use this when you want to connect to an external database instead of deploying MariaDB
+externalDatabase:
+  enabled: false
+  hostname: ""
+  port: 3306
+  database: uptime_kuma
+  username: uptime_kuma
+  password: ""
+  # Use existing secret for database credentials
+  existingSecret: ""
+  existingSecretPasswordKey: "password"
+  existingSecretUsernameKey: "username"
+
 # Prometheus ServiceMonitor configuration
 serviceMonitor:
   enabled: false


### PR DESCRIPTION
**Description of the change**
- Added configuration values for external database
- Added config validation for db (embedded vs external)
- Fixed StatefulSet template configuration (previously hardcoded or missing) + added missing wait-for-db init container
- Added helm unittests for validating templates

**Benefits**
- Cleaner implementation of configuration is needed since uptime is evolving in db adoption
- Healthchecks and updateStrategy in StatefulSet are now configurable

**Applicable issues**
  - fixes #193 

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
