### PR TITLE
chore: Bump Uptime-Kuma to 2.3.0

### DIFF
--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "2.1.1"
+appVersion: "2.3.0"
 deprecated: false
 description: A self-hosted Monitoring tool like "Uptime-Robot".
 home: https://github.com/dirsigler/uptime-kuma-helm
@@ -11,4 +11,4 @@ name: uptime-kuma
 sources:
   - https://github.com/louislam/uptime-kuma
 type: application
-version: 4.0.0
+version: 4.1.0

--- a/charts/uptime-kuma/README.md
+++ b/charts/uptime-kuma/README.md
@@ -1,6 +1,6 @@
 # uptime-kuma
 
-![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.1](https://img.shields.io/badge/AppVersion-2.1.1-informational?style=flat-square)
+![Version: 4.1.0](https://img.shields.io/badge/Version-4.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.0](https://img.shields.io/badge/AppVersion-2.3.0-informational?style=flat-square)
 
 A self-hosted Monitoring tool like "Uptime-Robot".
 
@@ -38,7 +38,7 @@ A self-hosted Monitoring tool like "Uptime-Robot".
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"louislam/uptime-kuma"` |  |
-| image.tag | string | `"2.1.1"` |  |
+| image.tag | string | `"2.3.0"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations."nginx.ingress.kubernetes.io/proxy-read-timeout" | string | `"3600"` |  |
 | ingress.annotations."nginx.ingress.kubernetes.io/proxy-send-timeout" | string | `"3600"` |  |

--- a/charts/uptime-kuma/values.yaml
+++ b/charts/uptime-kuma/values.yaml
@@ -6,7 +6,7 @@ image:
   repository: louislam/uptime-kuma
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "2.1.1"
+  tag: "2.3.0"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
**Description of the change**

Bumps Uptime Kuma `appVersion` from `2.1.1` to `2.3.0` and chart `version` from `4.0.0` to `4.1.0`. Updates `image.tag` in `values.yaml` accordingly and regenerates `README.md` via `helm-docs`.

**Benefits**

- Picks up Uptime Kuma `2.2.0` and `2.3.0` features (custom message templates for the Evolution provider, OracleDB monitor, Telnyx/VK/MAX notification providers, WebSocket auth, collapsible groups, and various bug fixes).
- Closes the gap with the renovate-suggested bump in #206 by going straight to the latest stable `2.3.0`.

**Possible drawbacks**

None known. No template changes required: the new `UPTIME_KUMA_SQLITE_SINGLE_CONNECTION` env var introduced in 2.3.0 is opt-in (only relevant on Raspberry Pi).

**Applicable issues**

Supersedes #206 (renovate bump to 2.2.1).

**Additional information**

- `helm lint charts/uptime-kuma/`: passes.
- `helm-docs --chart-search-root=charts/`: ran successfully.
- Tested in production by overriding `image.tag` to `2.3.0` on chart `4.0.0` (no template changes needed for the new app version).

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md