### PR TITLE
feat: add replicaCount value to scale workload to 0 or 1

### DIFF
--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -11,4 +11,4 @@ name: uptime-kuma
 sources:
   - https://github.com/louislam/uptime-kuma
 type: application
-version: 4.2.0
+version: 4.3.0

--- a/charts/uptime-kuma/README.md
+++ b/charts/uptime-kuma/README.md
@@ -81,6 +81,7 @@ A self-hosted Monitoring tool like "Uptime-Robot".
 | readinessProbe.periodSeconds | int | `10` |  |
 | readinessProbe.successThreshold | int | `1` |  |
 | readinessProbe.timeoutSeconds | int | `1` |  |
+| replicaCount | int | `1` | Number of replicas for the Deployment or StatefulSet. Uptime-Kuma is not horizontally scalable, so only 0 (paused) or 1 (running) are permitted. |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |
 | service.annotations | object | `{}` |  |

--- a/charts/uptime-kuma/README.md
+++ b/charts/uptime-kuma/README.md
@@ -1,6 +1,6 @@
 # uptime-kuma
 
-![Version: 4.2.0](https://img.shields.io/badge/Version-4.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
+![Version: 4.3.0](https://img.shields.io/badge/Version-4.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
 
 A self-hosted Monitoring tool like "Uptime-Robot".
 

--- a/charts/uptime-kuma/templates/_helpers.tpl
+++ b/charts/uptime-kuma/templates/_helpers.tpl
@@ -76,6 +76,18 @@ Set automountServiceAccountToken when service account is created
 {{- end }}
 
 {{/*
+Number of replicas. Uptime-Kuma is not horizontally scalable, so only 0
+(paused) or 1 (running) are permitted.
+*/}}
+{{- define "uptime-kuma.replicaCount" -}}
+{{- $replicas := int .Values.replicaCount -}}
+{{- if not (or (eq $replicas 0) (eq $replicas 1)) -}}
+{{- fail (printf "replicaCount must be 0 or 1, got %d" $replicas) -}}
+{{- end -}}
+{{- $replicas -}}
+{{- end }}
+
+{{/*
 Determine the namespace to use, allowing for a namespace override.
 */}}
 {{- define "uptime-kuma.namespace" -}}

--- a/charts/uptime-kuma/templates/deployment.yaml
+++ b/charts/uptime-kuma/templates/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "uptime-kuma.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ include "uptime-kuma.replicaCount" . }}
   selector:
     matchLabels:
       {{- include "uptime-kuma.selectorLabels" . | nindent 6 }}

--- a/charts/uptime-kuma/templates/statefulset.yaml
+++ b/charts/uptime-kuma/templates/statefulset.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "uptime-kuma.labels" . | nindent 4 }}
 spec:
   serviceName: {{ include "uptime-kuma.fullname" . }}
-  replicas: 1
+  replicas: {{ include "uptime-kuma.replicaCount" . }}
   {{- with .Values.strategy }}
   updateStrategy:
     {{- toYaml . | nindent 4 }}

--- a/charts/uptime-kuma/tests/deployment_test.yaml
+++ b/charts/uptime-kuma/tests/deployment_test.yaml
@@ -22,6 +22,23 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: should allow scaling to zero replicas
+    set:
+      useDeploy: true
+      replicaCount: 0
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 0
+
+  - it: should fail when replicaCount is greater than 1
+    set:
+      useDeploy: true
+      replicaCount: 2
+    asserts:
+      - failedTemplate:
+          errorMessage: "replicaCount must be 0 or 1, got 2"
+
   - it: should set correct image
     set:
       useDeploy: true

--- a/charts/uptime-kuma/tests/statefulset_test.yaml
+++ b/charts/uptime-kuma/tests/statefulset_test.yaml
@@ -22,6 +22,23 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: should allow scaling to zero replicas
+    set:
+      useDeploy: false
+      replicaCount: 0
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 0
+
+  - it: should fail when replicaCount is greater than 1
+    set:
+      useDeploy: false
+      replicaCount: 2
+    asserts:
+      - failedTemplate:
+          errorMessage: "replicaCount must be 0 or 1, got 2"
+
   - it: should set correct image
     set:
       useDeploy: false

--- a/charts/uptime-kuma/values.yaml
+++ b/charts/uptime-kuma/values.yaml
@@ -17,6 +17,10 @@ namespaceOverride: ""
 # If this option is set to false a StateFulset instead of a Deployment is used
 useDeploy: true
 
+# -- Number of replicas for the Deployment or StatefulSet. Uptime-Kuma is not
+# horizontally scalable, so only 0 (paused) or 1 (running) are permitted.
+replicaCount: 1
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: false


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Check if an open Issue exists that is solved by your changes.

 Thank you for contributing! I will try to test and integrate the change as soon as possible, but be aware that I can't immediately respond to every request.

 -->

**Description of the change**

Adds a configurable replicaCount value (default 1) used by both the Deployment and StatefulSet, replacing the previously hardcoded replicas: 1. A shared template helper validates the value and permits only 0 (paused) or 1 (running), failing rendering with a clear error otherwise.

**Benefits**

Lets users scale the workload to 0 to pause monitoring without uninstalling, or explicitly pin it to 1, without editing templates. For our use case we have dev and prod environment with same monitors. We don't want to run dev all the time but only when we need to test upgrades etc. This change will save time and costs so we enable dev only when needed to be tested.

**Possible drawbacks**

Uptime-Kuma is not horizontally scalable, so values above 1 are intentionally rejected rather than supported.

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
