### PR TITLE
feat: Add Gateway API HTTPRoute support

### DIFF
--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -11,4 +11,4 @@ name: uptime-kuma
 sources:
   - https://github.com/louislam/uptime-kuma
 type: application
-version: 4.2.0
+version: 4.3.0

--- a/charts/uptime-kuma/README.md
+++ b/charts/uptime-kuma/README.md
@@ -1,6 +1,6 @@
 # uptime-kuma
 
-![Version: 4.2.0](https://img.shields.io/badge/Version-4.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
+![Version: 4.3.0](https://img.shields.io/badge/Version-4.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
 
 A self-hosted Monitoring tool like "Uptime-Robot".
 
@@ -36,6 +36,13 @@ A self-hosted Monitoring tool like "Uptime-Robot".
 | externalDatabase.type | string | `"mariadb"` |  |
 | externalDatabase.username | string | `"uptime_kuma"` |  |
 | fullnameOverride | string | `""` |  |
+| httpRoute | object | `{"annotations":{},"enabled":false,"extraLabels":{},"hostnames":[],"parentRefs":[],"rules":[{"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]}` | Gateway API HTTPRoute configuration, can be used instead of the Ingress. Requires the Gateway API CRDs to be installed in the cluster. ref: https://gateway-api.sigs.k8s.io/api-types/httproute/ |
+| httpRoute.annotations | object | `{}` | Additional annotations to add to the HTTPRoute |
+| httpRoute.enabled | bool | `false` | Enable/disable the Gateway API HTTPRoute |
+| httpRoute.extraLabels | object | `{}` | Additional labels to add to the HTTPRoute |
+| httpRoute.hostnames | list | `[]` | Hostnames this HTTPRoute should match |
+| httpRoute.parentRefs | list | `[]` | Gateways this HTTPRoute should be attached to |
+| httpRoute.rules | list | `[{"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]` | HTTPRoute rules. If a rule specifies no backendRefs, the Uptime-Kuma Service is used as the backend automatically. Additional rule fields such as filters or timeouts are passed through as-is. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"louislam/uptime-kuma"` |  |
 | image.tag | string | `"2.5.0"` |  |

--- a/charts/uptime-kuma/templates/NOTES.txt
+++ b/charts/uptime-kuma/templates/NOTES.txt
@@ -5,6 +5,14 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
+{{- else if .Values.httpRoute.enabled }}
+{{- if .Values.httpRoute.hostnames }}
+{{- range .Values.httpRoute.hostnames }}
+  http://{{ . }}
+{{- end }}
+{{- else }}
+  The HTTPRoute is attached to your Gateway. Use the address of your Gateway to access Uptime-Kuma.
+{{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "uptime-kuma.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")

--- a/charts/uptime-kuma/templates/httproute.yaml
+++ b/charts/uptime-kuma/templates/httproute.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.httpRoute.enabled -}}
+{{- $fullName := include "uptime-kuma.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ include "uptime-kuma.namespace" . }}
+  labels:
+    {{- include "uptime-kuma.labels" . | nindent 4 }}
+    {{- if .Values.httpRoute.extraLabels }}
+      {{- toYaml .Values.httpRoute.extraLabels | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httpRoute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- range . }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.httpRoute.rules }}
+    - backendRefs:
+        {{- if .backendRefs }}
+        {{- toYaml .backendRefs | nindent 8 }}
+        {{- else }}
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+        {{- end }}
+      {{- with omit . "backendRefs" }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/uptime-kuma/tests/httproute_test.yaml
+++ b/charts/uptime-kuma/tests/httproute_test.yaml
@@ -1,0 +1,154 @@
+suite: test httproute
+templates:
+  - httproute.yaml
+tests:
+  - it: should not create httproute by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create httproute when enabled
+    set:
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+            namespace: my-gateway-namespace
+        hostnames:
+          - uptime-kuma.example.com
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - isAPIVersion:
+          of: gateway.networking.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-uptime-kuma
+      - equal:
+          path: spec.parentRefs[0].name
+          value: my-gateway
+      - equal:
+          path: spec.parentRefs[0].namespace
+          value: my-gateway-namespace
+      - equal:
+          path: spec.hostnames[0]
+          value: uptime-kuma.example.com
+
+  - it: should default the backend to the uptime-kuma service
+    set:
+      httpRoute:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: RELEASE-NAME-uptime-kuma
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 3001
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: PathPrefix
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /
+
+  - it: should allow custom backendRefs
+    set:
+      httpRoute:
+        enabled: true
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            backendRefs:
+              - name: custom-service
+                port: 8080
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: custom-service
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 8080
+
+  - it: should pass through additional rule fields
+    set:
+      httpRoute:
+        enabled: true
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            filters:
+              - type: RequestHeaderModifier
+                requestHeaderModifier:
+                  set:
+                    - name: X-Forwarded-Proto
+                      value: https
+            timeouts:
+              request: 3600s
+    asserts:
+      - equal:
+          path: spec.rules[0].filters[0].type
+          value: RequestHeaderModifier
+      - equal:
+          path: spec.rules[0].timeouts.request
+          value: 3600s
+
+  - it: should set httproute annotations
+    set:
+      httpRoute:
+        enabled: true
+        annotations:
+          example.com/annotation: my-annotation
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/annotation"]
+          value: my-annotation
+
+  - it: should add extra labels
+    set:
+      httpRoute:
+        enabled: true
+        extraLabels:
+          environment: production
+          team: monitoring
+    asserts:
+      - equal:
+          path: metadata.labels.environment
+          value: production
+      - equal:
+          path: metadata.labels.team
+          value: monitoring
+
+  - it: should handle multiple rules
+    set:
+      httpRoute:
+        enabled: true
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /metrics
+            backendRefs:
+              - name: metrics-service
+                port: 9090
+    asserts:
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: RELEASE-NAME-uptime-kuma
+      - equal:
+          path: spec.rules[1].matches[0].path.value
+          value: /metrics
+      - equal:
+          path: spec.rules[1].backendRefs[0].name
+          value: metrics-service

--- a/charts/uptime-kuma/values.yaml
+++ b/charts/uptime-kuma/values.yaml
@@ -89,6 +89,37 @@ ingress:
     #   hosts:
     #     - chart-example.local
 
+# -- Gateway API HTTPRoute configuration, can be used instead of the Ingress.
+# Requires the Gateway API CRDs to be installed in the cluster.
+# ref: https://gateway-api.sigs.k8s.io/api-types/httproute/
+httpRoute:
+  # -- Enable/disable the Gateway API HTTPRoute
+  enabled: false
+  # -- Additional annotations to add to the HTTPRoute
+  annotations: {}
+  # -- Additional labels to add to the HTTPRoute
+  extraLabels:
+    {}
+    # vhost: uptime-kuma.company.corp
+  # -- Gateways this HTTPRoute should be attached to
+  parentRefs:
+    []
+    # - name: my-gateway
+    #   namespace: my-gateway-namespace
+    #   sectionName: https
+  # -- Hostnames this HTTPRoute should match
+  hostnames:
+    []
+    # - chart-example.local
+  # -- HTTPRoute rules. If a rule specifies no backendRefs, the Uptime-Kuma
+  # Service is used as the backend automatically. Additional rule fields such
+  # as filters or timeouts are passed through as-is.
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+
 resources:
   {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
**Description of the change**

Adds optional Kubernetes Gateway API support to the chart via a new `HTTPRoute` template (`gateway.networking.k8s.io/v1`), configured through a new `httpRoute` section in `values.yaml`:

- Disabled by default (`httpRoute.enabled: false`), so existing installations are unaffected.
- `parentRefs`, `hostnames`, `annotations`, and `extraLabels` are configurable; the resource follows the same naming, labeling, and namespace conventions as the existing Ingress template.
- `rules` default to a `PathPrefix /` match. If a rule specifies no `backendRefs`, the Uptime-Kuma Service is used as the backend automatically. All other rule fields (`matches`, `filters`, `timeouts`, ...) are passed through as-is, so new Gateway API rule fields work without further chart changes.
- `NOTES.txt` prints the hostname URLs (or a pointer to the Gateway address) when the HTTPRoute is enabled.
- Includes a new `httproute_test.yaml` helm-unittest suite (8 tests) covering defaults, parentRefs/hostnames, the default service backend, custom backendRefs, filter/timeout pass-through, annotations, labels, and multiple rules.

**Benefits**

Users on clusters that route traffic with the Gateway API can expose Uptime-Kuma through an `HTTPRoute` attached to their Gateway instead of (or alongside) an Ingress.

**Possible drawbacks**

When enabled, the Gateway API CRDs must be installed in the cluster, otherwise the install fails. Since the feature is off by default, this does not affect the CI `ct install` job or existing users.

**Applicable issues**

  - fixes #233

**Additional information**

Verified with `helm lint`, `helm template` renders of the default, hostname, and complex (filters/timeouts/multi-rule) configurations, and `helm unittest` (67 tests passing, 8 new). README regenerated with helm-docs v1.14.2.

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)